### PR TITLE
Fix import of get_installed_distributions

### DIFF
--- a/check.py
+++ b/check.py
@@ -3,7 +3,7 @@ import pkg_resources
 import argparse
 import sys
 
-from pip.util import get_installed_distributions
+from pip.utils import get_installed_distributions
 
 
 def main():


### PR DESCRIPTION
`get_installed_distributions` is nowadays part of `pip.utils`. `pip.util` doesn't
exist anymore.
