### PR TITLE
Check multiple keys for possible license

### DIFF
--- a/check.py
+++ b/check.py
@@ -18,12 +18,15 @@ def main():
             if not installed_distribution.has_metadata(metafile):
                 continue
             for line in installed_distribution.get_metadata_lines(metafile):
-                if 'License: ' in line:
+                if 'License: ' in line or 'Classifier: License' in line:
                     (k, v) = line.split(': ', 1)
+                    if v == 'UNKNOWN':
+                        continue
                     sys.stdout.write("{project_name}: {license}\n".format(
                         project_name=installed_distribution.project_name,
                         license=v))
                     found_license = True
+                    break
         if not found_license:
             sys.stdout.write("{project_name}: Found no license information.\n".format(
                 project_name=installed_distribution.project_name))

--- a/check.py
+++ b/check.py
@@ -13,7 +13,7 @@ def main():
     meta_files_to_check = ['PKG-INFO', 'METADATA']
 
     for installed_distribution in get_installed_distributions():
-        found_license = False
+        license = 'UNKNOWN'
         for metafile in meta_files_to_check:
             if not installed_distribution.has_metadata(metafile):
                 continue
@@ -22,14 +22,12 @@ def main():
                     (k, v) = line.split(': ', 1)
                     if v == 'UNKNOWN':
                         continue
-                    sys.stdout.write("{project_name}: {license}\n".format(
-                        project_name=installed_distribution.project_name,
-                        license=v))
-                    found_license = True
+                    license = v
                     break
-        if not found_license:
-            sys.stdout.write("{project_name}: Found no license information.\n".format(
-                project_name=installed_distribution.project_name))
+        project_name = installed_distribution.project_name
+        version = installed_distribution.version
+        home = '/'.join(['https://pypi.python.org/pypi', project_name, version])
+        sys.stdout.write('"{}","{}","{}","{}"\n'.format(project_name, version, license, home))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Some packages seem to specify their license data in 'classifiers'. These
can look like the following:

$ cat /usr/lib/python2.7/site-packages/oslo.utils-3.30.0.dist-info/METADATA
...
Summary: Oslo Utility library
Home-page: https://docs.openstack.org/oslo.utils/latest/
License: UNKNOWN
Description-Content-Type: UNKNOWN
Classifier: License :: OSI Approved :: Apache Software License
...

This format is described in pep-0301 [0]

[0] https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification