### PR TITLE
Update importing pip as pip.utils is now obsolete

### DIFF
--- a/check.py
+++ b/check.py
@@ -3,7 +3,7 @@ import pkg_resources
 import argparse
 import sys
 
-from pip.utils import get_installed_distributions
+from pip._internal import get_installed_distributions
 
 
 def main():


### PR DESCRIPTION
In the recent versions of pip, `pip.utils` is obsolete. This PR replaces the import statement to make it work with the latest pip.